### PR TITLE
Twinfield expects string representation of boolean for "default" attribute

### DIFF
--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -208,7 +208,7 @@ class CustomersDocument extends BaseDocument
                 $addressesElement->appendChild($addressElement);
 
                 // Set attributes
-                $addressElement->setAttribute('default', $address->getDefault());
+                $addressElement->setAttribute('default', $address->getDefault() ? 'true' : 'false');
                 $addressElement->setAttribute('type', $address->getType());
 
                 // Go through each address element and use the assigned method
@@ -257,7 +257,7 @@ class CustomersDocument extends BaseDocument
                 $banksElement->appendChild($bankElement);
 
                 // Set attributes
-                $bankElement->setAttribute('default', $bank->getDefault());
+                $bankElement->setAttribute('default', $bank->getDefault() ? 'true' : 'false');
 
                 // Go through each bank element and use the assigned method
                 foreach ($bankTags as $tag => $method) {

--- a/src/Mappers/CustomerMapper.php
+++ b/src/Mappers/CustomerMapper.php
@@ -180,7 +180,7 @@ class CustomerMapper extends BaseMapper
                 $temp_address
                     ->setID($addressDOM->getAttribute('id'))
                     ->setType($addressDOM->getAttribute('type'))
-                    ->setDefault($addressDOM->getAttribute('default'));
+                    ->setDefault($addressDOM->getAttribute('default') === 'true');
 
                 // Loop through the element tags. Determine if it exists and set it if it does
                 foreach ($addressTags as $tag => $method) {
@@ -233,7 +233,7 @@ class CustomerMapper extends BaseMapper
                 // Set the attributes ( id, default )
                 $temp_bank
                     ->setID($bankDOM->getAttribute('id'))
-                    ->setDefault($bankDOM->getAttribute('default'));
+                    ->setDefault($bankDOM->getAttribute('default') === 'true');
 
                 // Loop through the element tags. Determine if it exists and set it if it does
                 foreach ($bankTags as $tag => $method) {

--- a/tests/IntegrationTests/CustomerIntegrationTest.php
+++ b/tests/IntegrationTests/CustomerIntegrationTest.php
@@ -78,7 +78,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
 
         $this->assertSame('1', $address->getID());
         $this->assertSame('invoice', $address->getType());
-        $this->assertSame('true', $address->getDefault());
+        $this->assertSame(true, $address->getDefault());
         $this->assertSame('Customer 0', $address->getName());
         $this->assertSame('NL', $address->getCountry());
         $this->assertSame('Place', $address->getCity());
@@ -103,7 +103,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
         $bank = $banks['-1'];
 
         $this->assertSame('-1', $bank->getID());
-        $this->assertSame('true', $bank->getDefault());
+        $this->assertSame(true, $bank->getDefault());
         $this->assertSame('Customer 1', $bank->getAscription());
         $this->assertSame('123456789', $bank->getAccountnumber());
         $this->assertSame('ABN Amro', $bank->getBankname());
@@ -178,7 +178,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
         $address = new CustomerAddress();
         $address->setID('1');
         $address->setType('invoice');
-        $address->setDefault('true');
+        $address->setDefault(true);
         $address->setName('Customer 0');
         $address->setCountry('NL');
         $address->setCity('Place');
@@ -192,7 +192,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
         $customer->addAddress($address);
 
         $bank = new CustomerBank();
-        $bank->setDefault('true');
+        $bank->setDefault(true);
         $bank->setAscription('Customer 1');
         $bank->setAccountnumber('123456789');
         $bank->setAddressField2('');

--- a/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
@@ -127,7 +127,7 @@ class CustomersDocumentUnitTest extends TestCase
             <comment>comment    comment</comment>
         </creditmanagement>
         <addresses>
-            <address default="1" type="invoice">
+            <address default="true" type="invoice">
                 <name>My Address</name>
                 <contact>My Contact</contact>
                 <country>nl</country>
@@ -145,7 +145,7 @@ class CustomersDocumentUnitTest extends TestCase
             </address>
         </addresses>
         <banks>
-            <bank default="1">
+            <bank default="true">
                 <ascription>ascriptor</ascription>
                 <accountnumber>account number</accountnumber>
                 <bankname>bank name</bankname>


### PR DESCRIPTION
Twinfield expects string representation of boolean ("true"/"false") instead of 1 or 0 for "default" attribute in XML for customer address and customer bank element.